### PR TITLE
Add a caret and a dollar to emailPattern

### DIFF
--- a/src/github.com/astaxie/beego/validation/validators.go
+++ b/src/github.com/astaxie/beego/validation/validators.go
@@ -518,7 +518,7 @@ func (a AlphaDash) GetLimitValue() interface{} {
 	return nil
 }
 
-var emailPattern = regexp.MustCompile("[\\w!#$%&'*+/=?^_`{|}~-]+(?:\\.[\\w!#$%&'*+/=?^_`{|}~-]+)*@(?:[\\w](?:[\\w-]*[\\w])?\\.)+[a-zA-Z0-9](?:[\\w-]*[\\w])?")
+var emailPattern = regexp.MustCompile("^[\\w!#$%&'*+/=?^_`{|}~-]+(?:\\.[\\w!#$%&'*+/=?^_`{|}~-]+)*@(?:[\\w](?:[\\w-]*[\\w])?\\.)+[a-zA-Z0-9](?:[\\w-]*[\\w])?$")
 
 // Email check struct
 type Email struct {


### PR DESCRIPTION
Hello, thanks for providing such a good system!

I found `emailPattern` has no caret ( `^` ) and no dollar ( `$` ) .
It means this regular expression allows any character as a prefix or a suffix.

Could you please accept this modification?

Thanks!