### PR TITLE
增加若干特性：ldap用户认证支持、上线时对比版本差异、项目锁定禁止发布等等

### DIFF
--- a/src/conf/app.conf
+++ b/src/conf/app.conf
@@ -1,6 +1,6 @@
 appname = gopub
 httpport = 8080
-runmode = prod
+runmode = dev
 ServerName  = "gopub"
 EnableGzip 	= true
 AutoRender = true
@@ -11,10 +11,31 @@ Graceful= false
 EnableHTTP=true
 HttpAddr=0.0.0.0
 
+#jumpserver
+jumpserver = "http://jump.test.com"
+jump_username = ""
+jump_password = ""
+jump_auth_api="/api/users/v1/auth/"
+jump_grouplist_api = "/api/v1/assets/nodes/"
+jump_groupid2ips_api = "/api/v1/assets/assets/?node_id=%id"
 
 SessionOn= true
 SessionGCMaxLifetime=86400
 SessionCookieLifeTime=86400
+
+enableLdap = false
+ldapHost = "127.0.0.1"
+ldapPort = 389
+ldapPeopleDn = "ou=People,dc=test,dc=com"
+ldapPeopleDnTpl = "uid={uid},ou=People,dc=test,dc=com"
+ldapGroupDn = "ou=Group,dc=test,dc=com"
+ldapGroupFilter = "(&(cn=gopub*)(memberUid=gopub))"
+ldapGroupName2roleid_gopubAdmin = 1
+ldapGroupName2roleid_gopubPre = 10
+ldapGroupName2roleid_gopubSingle = 20
+
+
+
 [dev]
 HttpPort = 8192
 HttpsPort=12448

--- a/src/controllers/changepasswd.go
+++ b/src/controllers/changepasswd.go
@@ -3,11 +3,11 @@ package controllers
 import (
 	"github.com/astaxie/beego"
 
+	"encoding/json"
 	"github.com/astaxie/beego/orm"
 	"golang.org/x/crypto/bcrypt"
+	"library/common"
 	"models"
-
-	"encoding/json"
 )
 
 type ChangePasswdController struct {
@@ -16,45 +16,50 @@ type ChangePasswdController struct {
 
 func (c *ChangePasswdController) Post() {
 	//哈希校验成功后 更新 auth_key
+	if c.User == nil || c.User.Id == 0 {
+		c.SetJson(2, nil, "not login")
+		return
+	}
+
 	beego.Info(string(c.Ctx.Input.RequestBody))
 
-	postData := map[string]string{"old_password": "", "newpassword": "", "repeat_newpassword": ""}
+	postData := map[string]string{"newpassword": "", "repeat_newpassword": ""}
 	err := json.Unmarshal(c.Ctx.Input.RequestBody, &postData)
 	if err != nil {
 		c.SetJson(1, nil, "数据格式错误")
 		return
 	}
-	oldPassword := postData["old_password"]
+
+	uid := postData["uid"]
+	if common.GetString(c.User.Id) != uid && c.User.Role != 1 {
+		c.SetJson(1, nil, "403")
+		return
+	}
 	newPassword := postData["newpassword"]
 	repeatNewpassword := postData["repeat_newpassword"]
-	if oldPassword == "" || newPassword == "" || repeatNewpassword == "" {
+	if newPassword == "" || repeatNewpassword == "" {
 		c.SetJson(1, nil, "请输入密码")
 		return
 	}
 	var user models.User
 	o := orm.NewOrm()
-	err = o.Raw("SELECT * FROM `user` WHERE id= ?", c.User.Id).QueryRow(&user)
-	beego.Info(user)
+	err = o.Raw("SELECT * FROM `user` WHERE id= ?", uid).QueryRow(&user)
+	beego.Info(err)
 	//验证旧密码
-	err = bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(oldPassword))
-	if err != nil {
-		c.SetJson(1, nil, "旧密码有误，请重新输入")
+
+	if newPassword == repeatNewpassword {
+		password := []byte(newPassword)
+		hashedPassword, err := bcrypt.GenerateFromPassword(password, bcrypt.DefaultCost)
+		if err != nil {
+			panic(err)
+		}
+		user.PasswordHash = string(hashedPassword)
+		models.UpdateUserById(&user)
+		c.Data["json"] = map[string]interface{}{"code": 0, "msg": "sucess"}
+		c.ServeJSON()
 		return
 	} else {
-		if newPassword == repeatNewpassword {
-			password := []byte(newPassword)
-			hashedPassword, err := bcrypt.GenerateFromPassword(password, bcrypt.DefaultCost)
-			if err != nil {
-				panic(err)
-			}
-			user.PasswordHash = string(hashedPassword)
-			models.UpdateUserById(&user)
-			c.Data["json"] = map[string]interface{}{"code": 0, "msg": "sucess"}
-			c.ServeJSON()
-			return
-		} else {
-			c.SetJson(1, nil, "两次密码输入不一致，请重新输入")
-			return
-		}
+		c.SetJson(1, nil, "两次密码输入不一致，请重新输入")
+		return
 	}
 }

--- a/src/controllers/conf/groupinfo.go
+++ b/src/controllers/conf/groupinfo.go
@@ -1,0 +1,62 @@
+package confcontrollers
+
+import (
+	"controllers"
+	"github.com/astaxie/beego"
+	"library/common"
+
+	"library/jumpserver"
+	"strings"
+)
+
+type GroupInfoController struct {
+	controllers.BaseController
+}
+
+func (c *GroupInfoController) Get() {
+	if c.User == nil || c.User.Id == 0 {
+		c.SetJson(2, nil, "not login")
+		return
+	}
+	groupid := c.GetString("hostgroup")
+	if groupid == "" {
+		c.SetJson(1, nil, "params")
+	}
+	aGroupid := strings.Split(groupid, " ")
+	if len(aGroupid) < 1 {
+		c.SetJson(1, nil, "params array")
+	}
+
+	mGroupid2true := make(map[string]bool)
+	var rsIps []string
+	for _, gid := range aGroupid {
+		aIp, _ := jumpserver.GetIpsByGroupid(string(gid))
+		beego.Info(aIp)
+		mGroupid2true[string(gid)] = true
+		if len(aIp) > 0 {
+			for ip, _ := range aIp {
+				rsIps = append(rsIps, ip)
+			}
+		}
+	}
+	rsIps = common.ArrayUnique(rsIps)
+
+	rsId2Groupname := make(map[string]string)
+	group2id, _ := jumpserver.GetGroups()
+	if len(group2id) > 0 {
+		for group_id, groupname := range group2id {
+			_, ok := mGroupid2true[group_id]
+			if ok == true {
+				rsId2Groupname[group_id] = groupname
+			}
+
+		}
+	}
+
+	rs := make(map[string]interface{})
+	rs["id2groupname"] = rsId2Groupname
+	rs["ips"] = rsIps
+
+	c.SetJson(0, rs, "")
+	return
+}

--- a/src/controllers/conf/lock.go
+++ b/src/controllers/conf/lock.go
@@ -1,0 +1,39 @@
+package confcontrollers
+
+import (
+	"controllers"
+	"models"
+)
+
+type LockController struct {
+	controllers.BaseController
+}
+
+func (c *LockController) Get() {
+	if c.User == nil || c.User.Id == 0 {
+		c.SetJson(2, nil, "not login")
+		return
+	}
+	projectId, _ := c.GetInt("projectId", 0)
+	// 1为锁定 0为解锁
+	act, _ := c.GetInt("act", 0)
+
+	project, err := models.GetProjectById(projectId)
+	if err != nil {
+		c.SetJson(1, nil, err.Error())
+	}
+
+	if act == 1 {
+		project.UserLock = int16(c.User.Id)
+	} else {
+		project.UserLock = 0
+	}
+
+	err = models.UpdateProjectById(project)
+	if err != nil {
+		c.SetJson(1, nil, err.Error())
+		return
+	}
+	c.SetJson(0, nil, "锁定成功")
+	return
+}

--- a/src/controllers/conf/mylist.go
+++ b/src/controllers/conf/mylist.go
@@ -30,7 +30,7 @@ func (c *MyListController) Get() {
 		where = where + "and  id in (SELECT project_id FROM `group` WHERE `group`.user_id=" + common.GetString(c.User.Id) + " )  "
 
 	}
-	o.Raw("SELECT *, (SELECT realname FROM `user` WHERE `user`.id=project.user_id LIMIT 1) as realname FROM `project`  WHERE 1=1 "+where+" ORDER BY id LIMIT ?,?", start, length).Values(&projects)
+	o.Raw("SELECT *, (SELECT realname FROM `user` WHERE `user`.id=project.user_id LIMIT 1) as realname,(SELECT realname FROM `user` WHERE `user`.id=project.user_lock LIMIT 1) as lockuser FROM `project`  WHERE 1=1 "+where+" ORDER BY id LIMIT ?,?", start, length).Values(&projects)
 	var count []orm.Params
 	total := 0
 	o.Raw("SELECT count(id) FROM `project` WHERE 1=1 " + where).Values(&count)

--- a/src/controllers/conf/server_groups.go
+++ b/src/controllers/conf/server_groups.go
@@ -1,0 +1,20 @@
+package confcontrollers
+
+import (
+	"controllers"
+	"library/jumpserver"
+)
+
+type ServerGroupsController struct {
+	controllers.BaseController
+}
+
+func (c *ServerGroupsController) Get() {
+	if c.User == nil || c.User.Id == 0 {
+		c.SetJson(2, nil, "not login")
+		return
+	}
+	group2id, _ := jumpserver.GetGroups()
+	c.SetJson(0, group2id, "")
+	return
+}

--- a/src/controllers/conf/tags.go
+++ b/src/controllers/conf/tags.go
@@ -1,0 +1,42 @@
+package confcontrollers
+
+import (
+	"controllers"
+	"github.com/astaxie/beego/orm"
+	"library/common"
+	"strings"
+)
+
+type TagsController struct {
+	controllers.BaseController
+}
+
+func (c *TagsController) Get() {
+	if c.User == nil || c.User.Id == 0 {
+		c.SetJson(2, nil, "not login")
+		return
+	}
+
+	var rows []orm.Params
+	o := orm.NewOrm()
+	o.Raw("SELECT tag FROM `project`").Values(&rows)
+
+	var a []string
+	if len(rows) > 0 {
+		for _, row := range rows {
+			tmp := strings.Split(common.GetString(row["tag"]), " ")
+			if len(tmp) > 0 {
+				for _, tag := range tmp {
+					if tag != "" {
+						a = append(a, tag)
+					}
+				}
+			}
+		}
+	}
+
+	a = common.ArrayUnique(a)
+	c.SetJson(0, a, "")
+	return
+
+}

--- a/src/controllers/login.go
+++ b/src/controllers/login.go
@@ -7,7 +7,10 @@ import (
 	"github.com/astaxie/beego/orm"
 	"golang.org/x/crypto/bcrypt"
 	"library/common"
+	"library/ldap"
 	"models"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -34,18 +37,97 @@ func (c *LoginController) Post() {
 	o := orm.NewOrm()
 	err = o.Raw("SELECT * FROM `user` WHERE username= ?", userName).QueryRow(&user)
 	beego.Info(user)
-	err = bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(password))
-	if err != nil {
-		c.SetJson(1, nil, "用户名或密码错误")
-		return
-	} else {
-		if user.AuthKey == "" {
+
+	enableLdap, _ := beego.AppConfig.Bool("enableLdap")
+	if enableLdap == true {
+		msg, user, isOk := c.ldapLogin(userName, password, user)
+		if !isOk {
+			c.SetJson(1, nil, msg)
+			return
+		} else {
 			userAuth := common.Md5String(user.Username + common.GetString(time.Now().Unix()))
 			user.AuthKey = userAuth
 			models.UpdateUserById(&user)
+			c.SetJson(0, user, "")
+			return
+
 		}
-		user.PasswordHash = ""
-		c.SetJson(0, user, "")
-		return
+	} else {
+		err = bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(password))
+		if err != nil {
+			c.SetJson(1, nil, "用户名或密码错误")
+			return
+		} else {
+			if user.AuthKey == "" {
+				userAuth := common.Md5String(user.Username + common.GetString(time.Now().Unix()))
+				user.AuthKey = userAuth
+				models.UpdateUserById(&user)
+			}
+			user.PasswordHash = ""
+			c.SetJson(0, user, "")
+			return
+		}
 	}
+}
+
+func (c *LoginController) ldapLogin(userName string, password string, gopub_user models.User) (msg string, user models.User, isOk bool) {
+	ldap := ldap.Ldap{}
+	e := ldap.Connect()
+	if e != nil {
+		return "ldap连接失败", gopub_user, false
+	}
+	//验证用户身份
+	ldap_user, e := ldap.AuthByUidAndPassword(userName, password)
+	if e != nil {
+		return "ldap身份认证失败", gopub_user, false
+	}
+	//验证是否在gopub用户组
+	ldapGroupFilter := beego.AppConfig.String("ldapGroupFilter")
+	ldapGroupFilter = strings.Replace(ldapGroupFilter, "{UidNumber}", ldap_user.UidNumber, -1)
+	ldapGroupFilter = strings.Replace(ldapGroupFilter, "{uid}", ldap_user.Uid, -1)
+	ldapGroupFilter = strings.Replace(ldapGroupFilter, "{cn}", ldap_user.Cn, -1)
+	ldapGroupFilter = strings.Replace(ldapGroupFilter, "{sn}", ldap_user.Sn, -1)
+
+	groupCn, e := ldap.SearchGroupCn(ldapGroupFilter)
+	if e != nil {
+		beego.Info("ldap组身份验证失败")
+		return "ldap组身份验证失败", gopub_user, false
+	} else {
+		o := orm.NewOrm()
+
+		role_id64, _ := strconv.ParseInt(beego.AppConfig.String("ldapGroupName2roleid_"+groupCn), 10, 64)
+		role_id := int16(role_id64)
+		// 用户不存在，自动同步进gopub数据库
+		if gopub_user.Username == "" {
+			c.AddUserFromLdap2Gopub(ldap_user, role_id)
+			_ = o.Raw("SELECT * FROM `user` WHERE username= ?", userName).QueryRow(&gopub_user)
+			beego.Info(gopub_user)
+		} else {
+			//role变更
+			if role_id != gopub_user.Role {
+				gopub_user.Role = role_id
+				models.UpdateUserById(&gopub_user)
+			}
+		}
+
+		return "", gopub_user, true
+	}
+
+}
+
+func (c *LoginController) AddUserFromLdap2Gopub(user ldap.Ldap_user, role_id int16) {
+	uidNumber, _ := strconv.Atoi(user.UidNumber)
+
+	userModel := models.User{}
+	userModel.Id = uidNumber
+	userModel.Username = user.Uid
+	userModel.Email = user.Email
+	userModel.Realname = user.Cn
+	userModel.CreatedAt = time.Now()
+	userModel.UpdatedAt = time.Now()
+	userModel.Avatar = "default.jpg"
+	userModel.Role = role_id
+	userModel.FromLdap = 1
+	uid, _ := models.AddUser(&userModel)
+	beego.Info(uid)
 }

--- a/src/controllers/register.go
+++ b/src/controllers/register.go
@@ -74,13 +74,19 @@ func (c *RegisterController) Post() {
 				o.Raw("INSERT INTO `group`(`project_id`, `user_id`) VALUES (?, ?)", pro_id, user.Id).Exec()
 			}
 		}
-		err := models.UpdateUserById(&user)
-		if err != nil {
-			c.SetJson(1, nil, "数据库存储错误")
-			return
+		if user.FromLdap == 0 {
+			err := models.UpdateUserById(&user)
+
+			if err != nil {
+				c.SetJson(1, nil, "数据库存储错误")
+				return
+			} else {
+				c.SetJson(0, nil, "success")
+				return
+			}
 		} else {
 			c.SetJson(0, nil, "success")
-			return
+
 		}
 
 	} else { //不存在，存库

--- a/src/controllers/task/changes.go
+++ b/src/controllers/task/changes.go
@@ -1,0 +1,56 @@
+package taskcontrollers
+
+import (
+	"controllers"
+	"github.com/astaxie/beego/orm"
+	"library/components"
+	"models"
+)
+
+type ChangesController struct {
+	controllers.BaseController
+}
+
+func (c *ChangesController) Get() {
+	taskId, _ := c.GetInt("taskId", 0)
+
+	if taskId == 0 {
+		c.SetJson(1, nil, "Parameter error")
+		return
+	}
+	o := orm.NewOrm()
+
+	var task models.Task
+	o.Raw("SELECT * FROM task where task.id = ?", taskId).QueryRow(&task)
+
+	project, _ := models.GetProjectById(task.ProjectId)
+
+	if project.RepoType == "git" {
+		var last_task models.Task
+		o.Raw("SELECT * FROM task where project_id = ? AND status=3 order by task.id DESC LIMIT 1", task.ProjectId).QueryRow(&last_task)
+
+		s := components.BaseComponents{}
+		s.SetProject(project)
+		s.SetTask(&task)
+
+		g := components.BaseGit{}
+		g.SetBaseComponents(s)
+		files, _ := g.DiffBetweenCommits(task.Branch, task.CommitId, last_task.CommitId)
+
+		var fileinfos []map[string]string
+		if len(files) < 10 && len(files) > 0 {
+			for _, filepath := range files {
+				fileinfo, _ := g.GetLastModifyInfo(task.Branch, filepath)
+				fileinfo["path"] = filepath
+				fileinfos = append(fileinfos, fileinfo)
+			}
+		} else {
+
+		}
+		c.SetJson(0, fileinfos, "")
+		return
+	} else {
+		c.SetJson(1, nil, "Project is not git")
+	}
+
+}

--- a/src/controllers/task/save.go
+++ b/src/controllers/task/save.go
@@ -37,6 +37,7 @@ func (c *SaveController) Post() {
 			ss, err := models.GetProjectById(task.ProjectId)
 			if err == nil {
 				task.Hosts = ss.Hosts
+				task.HostGroup = ss.HostGroup
 			}
 			if ss.IsGroup == 1 {
 				s := components.BaseComponents{}

--- a/src/library/common/common.go
+++ b/src/library/common/common.go
@@ -310,3 +310,19 @@ func SubString(str string, begin, length int) (substr string) {
 	// 返回子串
 	return string(rs[begin:end])
 }
+func ArrayUnique(arr []string) (newArr []string) {
+	newArr = make([]string, 0)
+	for i := 0; i < len(arr); i++ {
+		repeat := false
+		for j := i + 1; j < len(arr); j++ {
+			if arr[i] == arr[j] {
+				repeat = true
+				break
+			}
+		}
+		if !repeat {
+			newArr = append(newArr, arr[i])
+		}
+	}
+	return
+}

--- a/src/library/components/base.go
+++ b/src/library/components/base.go
@@ -6,6 +6,7 @@ import (
 	"github.com/astaxie/beego"
 	"github.com/gaoyue1989/sshexec"
 	"library/common"
+	"library/jumpserver"
 	"library/ssh"
 	"models"
 	"regexp"
@@ -148,10 +149,33 @@ type HostInfo struct {
 	AllHost string
 }
 
+func (c *BaseComponents) GetHosts() []HostInfo {
+	hostgroupStr := c.project.HostGroup
+	aGroupid := strings.Split(hostgroupStr, " ")
+	res := []HostInfo{}
+	port := 22
+	if len(aGroupid) > 0 {
+		for _, gid := range aGroupid {
+			aIp2hostname, _ := jumpserver.GetIpsByGroupid(string(gid))
+			if len(aIp2hostname) > 0 {
+				for ip, _ := range aIp2hostname {
+					res = append(res, HostInfo{
+						Ip:      ip,
+						Port:    port,
+						Group:   1,
+						AllHost: ip + ":" + common.GetString(port)})
+				}
+			}
+		}
+	}
+
+	return res
+}
+
 /**
  * 获取host
  */
-func (c *BaseComponents) GetHosts() []HostInfo {
+func (c *BaseComponents) GetHosts_bak() []HostInfo {
 	hostsStr := c.project.Hosts
 	if c.task != nil && c.task.Hosts != "" {
 		hostsStr = c.task.Hosts

--- a/src/library/components/ldap.go
+++ b/src/library/components/ldap.go
@@ -1,0 +1,35 @@
+package components
+
+import (
+	"fmt"
+	"github.com/astaxie/beego"
+	ldap "gopkg.in/ldap.v3"
+)
+
+type Ldap struct {
+	link *ldap.Conn
+}
+
+func new_ldap() (l Ldap) {
+	l.connect()
+	return l
+}
+
+func (l *Ldap) connect() (err bool) {
+	ldapHost := beego.AppConfig.String("ldapHost")
+	ldapPort, _ := beego.AppConfig.Int("ldapPort")
+	link, e := ldap.Dial("tcp", fmt.Sprintf("%s:%d", ldapHost, ldapPort))
+
+	if e != nil {
+		beego.Info("ldap connect error")
+		return false
+	}
+
+	e = link.Bind(beego.AppConfig.String("ldapManagerDn"), beego.AppConfig.String("ldapManagerPassword"))
+	if e != nil {
+		beego.Info("ldap login error")
+		return false
+	}
+	l.link = link
+	return true
+}

--- a/src/library/jumpserver/api.go
+++ b/src/library/jumpserver/api.go
@@ -1,0 +1,101 @@
+package jumpserver
+
+import (
+	"encoding/json"
+	"github.com/astaxie/beego"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+// type gid2hostinfo struct {
+// 	gid ip2hostname
+// }
+type authinfo struct {
+	Token string
+	//	User interface{}
+}
+
+type asset struct {
+	Ip       string `json:ip`
+	Hostname string `json:hostname`
+}
+
+type node struct {
+	Id    string `json:id`
+	Value string `json:value`
+}
+
+func auth() (string, error) {
+	auth_api_url := beego.AppConfig.String("jumpserver") + beego.AppConfig.String("jump_auth_api")
+	param := "{\"username\": \"" + beego.AppConfig.String("jump_username") + "\", \"password\": \"" + beego.AppConfig.String("jump_password") + "\"}"
+	resp, _ := http.Post(auth_api_url, "application/json", strings.NewReader(param))
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	rs := authinfo{}
+	err = json.Unmarshal([]byte(body), &rs)
+	if err != nil {
+		return "", nil
+	}
+	return string(rs.Token), nil
+}
+func GetGroups() (map[string]string, error) {
+	token, err := auth()
+	if err != nil {
+		return nil, err
+	}
+
+	jumpserver_grouplist_api_url := beego.AppConfig.String("jumpserver") + beego.AppConfig.String("jump_grouplist_api")
+
+	client := &http.Client{}
+	request, err := http.NewRequest("GET", jumpserver_grouplist_api_url, strings.NewReader(""))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Authorization", "Bearer "+token)
+	resp, err := client.Do(request)
+	defer resp.Body.Close()
+
+	body, _ := ioutil.ReadAll(resp.Body)
+	var rs []node
+	err = json.Unmarshal(body, &rs)
+	id2group := make(map[string]string)
+	if len(rs) > 0 {
+		for _, nodeinfo := range rs {
+			if strings.HasPrefix(nodeinfo.Value, "up_") == true {
+				id2group[nodeinfo.Id] = nodeinfo.Value
+			}
+		}
+	}
+	if err != nil {
+		return nil, nil
+	}
+	return id2group, nil
+}
+
+func GetIpsByGroupid(group_id string) (map[string]string, error) {
+	token, err := auth()
+	if err != nil {
+		return nil, err
+	}
+
+	jumpserver_grouplist_api_url := beego.AppConfig.String("jumpserver") + strings.Replace(beego.AppConfig.String("jump_groupid2ips_api"), "%id", string(group_id), -1)
+	client := &http.Client{}
+	request, err := http.NewRequest("GET", jumpserver_grouplist_api_url, strings.NewReader(""))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Authorization", "Bearer "+token)
+	resp, err := client.Do(request)
+	defer resp.Body.Close()
+
+	body, _ := ioutil.ReadAll(resp.Body)
+	var rs []asset
+	err = json.Unmarshal([]byte(body), &rs)
+	ip2hostname := make(map[string]string)
+	if len(rs) > 0 {
+		for _, v := range rs {
+			ip2hostname[v.Ip] = v.Hostname
+		}
+	}
+	if err != nil {
+		return nil, nil
+	}
+	return ip2hostname, nil
+}

--- a/src/library/ldap/ldap.go
+++ b/src/library/ldap/ldap.go
@@ -1,0 +1,109 @@
+package ldap
+
+import (
+	"fmt"
+	"github.com/astaxie/beego"
+	ldap "gopkg.in/ldap.v3"
+	"strings"
+)
+
+type Ldap struct {
+	link *ldap.Conn
+}
+type Ldap_user struct {
+	Uid       string
+	Cn        string
+	Sn        string
+	Email     string
+	UidNumber string
+}
+
+func (l *Ldap) Connect() (e error) {
+	ldapHost := beego.AppConfig.String("ldapHost")
+	ldapPort, _ := beego.AppConfig.Int("ldapPort")
+	beego.Debug(fmt.Sprintf("try to connect ldap: %s:%d", ldapHost, ldapPort))
+
+	link, e := ldap.Dial("tcp", fmt.Sprintf("%s:%d", ldapHost, ldapPort))
+	if e != nil {
+		beego.Info(e)
+		return e
+	}
+
+	l.link = link
+	return e
+}
+
+func (l *Ldap) Search(baseDn string, query string) (rs *ldap.SearchResult, e error) {
+	beego.Debug("search:" + query)
+	searchRequest := ldap.NewSearchRequest(
+		baseDn, // The base dn to search
+		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
+		query,         // The filter to apply
+		[]string{"*"}, // A list attributes to retrieve
+		nil,
+	)
+	rs, e = l.link.Search(searchRequest)
+	if e != nil {
+		beego.Info(e)
+	}
+	return rs, e
+}
+
+func (l *Ldap) SearchUser(uid string) (users []Ldap_user, e error) {
+	baseDn := beego.AppConfig.String("ldapPeopleDn")
+	query := fmt.Sprintf("(uid=%s)", uid)
+	beego.Debug("search user" + baseDn + query)
+	rs, e := l.Search(baseDn, query)
+	if e == nil {
+		for _, entry := range rs.Entries {
+			user := l.formatUser(entry)
+			users = append(users, user)
+		}
+		return users, nil
+	} else {
+		return nil, e
+	}
+
+}
+func (l *Ldap) formatUser(entry *ldap.Entry) (user Ldap_user) {
+	user.Cn = entry.GetAttributeValue("cn")
+	user.Sn = entry.GetAttributeValue("sn")
+	user.Uid = entry.GetAttributeValue("uid")
+	user.UidNumber = entry.GetAttributeValue("uidNumber")
+	user.Email = entry.GetAttributeValue("mail")
+	return user
+}
+func (l *Ldap) AuthByUidAndPassword(uid string, password string) (user Ldap_user, e error) {
+	userDn := strings.Replace(beego.AppConfig.String("ldapPeopleDnTpl"), "{uid}", uid, -1)
+	beego.Debug("auth user: " + userDn)
+	e = l.link.Bind(userDn, password)
+
+	if e == nil {
+		beego.Debug("ldap auth succ")
+		baseDn := beego.AppConfig.String("ldapPeopleDn")
+		userEntry, e := l.Search(baseDn, fmt.Sprintf("(uid=%s)", uid))
+		if e != nil {
+			return user, e
+		} else {
+			user := l.formatUser(userEntry.Entries[0])
+			return user, nil
+		}
+	} else {
+		return user, e
+	}
+}
+func (l *Ldap) SearchGroupCn(query string) (cn string, e error) {
+
+	baseDn := beego.AppConfig.String("ldapGroupDn")
+	rs, e := l.Search(baseDn, query)
+	if e == nil {
+		if len(rs.Entries) > 0 {
+			return rs.Entries[0].GetAttributeValue("cn"), nil
+		} else {
+			beego.Info("user is not in cronsun group " + query)
+			return "", fmt.Errorf("user is not in cronsun group")
+		}
+	} else {
+		return "", e
+	}
+}

--- a/src/models/project.go
+++ b/src/models/project.go
@@ -10,38 +10,46 @@ import (
 	"github.com/astaxie/beego/orm"
 )
 
+const RELEASE_TYPE_SOFTLINK = 0
+const RELEASE_TYPE_MOVEDIR = 1
+
 type Project struct {
-	Id             int       `orm:"column(id);auto"`
-	UserId         uint      `orm:"column(user_id)"`
-	Name           string    `orm:"column(name);size(100);null"`
-	Level          int16     `orm:"column(level)"`
-	Status         int16     `orm:"column(status)"`
-	Version        string    `orm:"column(version);size(32);null"`
-	RepoUrl        string    `orm:"column(repo_url);type(text);null"`
-	RepoUsername   string    `orm:"column(repo_username);size(50);null"`
-	RepoPassword   string    `orm:"column(repo_password);size(100);null"`
-	RepoMode       string    `orm:"column(repo_mode);size(50);null"`
-	RepoType       string    `orm:"column(repo_type);size(10);null"`
-	DeployFrom     string    `orm:"column(deploy_from);size(200)"`
-	Excludes       string    `orm:"column(excludes);type(text);null"`
-	ReleaseUser    string    `orm:"column(release_user);size(50)"`
-	ReleaseTo      string    `orm:"column(release_to);size(200)"`
-	ReleaseLibrary string    `orm:"column(release_library);type(text);size(200)"`
-	Hosts          string    `orm:"column(hosts);type(text);null"`
-	PreDeploy      string    `orm:"column(pre_deploy);type(text);null"`
-	PostDeploy     string    `orm:"column(post_deploy);type(text);null"`
-	PreRelease     string    `orm:"column(pre_release);type(text);null"`
-	PostRelease    string    `orm:"column(post_release);type(text);null"`
-	LastDeploy     string    `orm:"column(last_deploy);type(text);null"`
-	Audit          int16     `orm:"column(audit);null"`
-	KeepVersionNum int       `orm:"column(keep_version_num)"`
-	CreatedAt      time.Time `orm:"column(created_at);type(datetime);null"`
-	UpdatedAt      time.Time `orm:"column(updated_at);type(datetime);null"`
-	P2p            int16     `orm:"column(p2p)"`
-	HostGroup      string    `orm:"column(host_group)"`
-	Gzip           int16     `orm:"column(gzip)"`
-	IsGroup        int16     `orm:"column(is_group)"`
-	PmsProName     string    `orm:"column(pms_pro_name);size(200)"`
+	Id                  int       `orm:"column(id);auto"`
+	UserId              uint      `orm:"column(user_id)"`
+	Name                string    `orm:"column(name);size(100);null"`
+	Tag                 string    `orm:"column(tag);size(100);null"` //标签 用户分组显示
+	Level               int16     `orm:"column(level)"`
+	Status              int16     `orm:"column(status)"`
+	Version             string    `orm:"column(version);size(32);null"`
+	RepoUrl             string    `orm:"column(repo_url);type(text);null"`
+	RepoUsername        string    `orm:"column(repo_username);size(50);null"`
+	RepoPassword        string    `orm:"column(repo_password);size(100);null"`
+	RepoMode            string    `orm:"column(repo_mode);size(50);null"`
+	RepoType            string    `orm:"column(repo_type);size(10);null"`
+	DeployFrom          string    `orm:"column(deploy_from);size(200)"`
+	Excludes            string    `orm:"column(excludes);type(text);null"`
+	ReleaseUser         string    `orm:"column(release_user);size(50)"`
+	ReleaseTo           string    `orm:"column(release_to);size(200)"`
+	ReleaseLibrary      string    `orm:"column(release_library);type(text);size(200)"`
+	ReleaseType         int16     `orm:"column(release_type)"` //发布方式 0短链接 1移动目录
+	Hosts               string    `orm:"column(hosts);type(text);null"`
+	PreDeploy           string    `orm:"column(pre_deploy);type(text);null"`
+	PostDeploy          string    `orm:"column(post_deploy);type(text);null"`
+	PreRelease          string    `orm:"column(pre_release);type(text);null"`
+	PostRelease         string    `orm:"column(post_release);type(text);null"`
+	PostReleaseTogether string    `orm:"column(post_release_together);type(text);null"` //所有服务器部属完成后，再统一执行的命令，主要防止单机部属速度不一而导致如服务重启不同时的问题
+	LastDeploy          string    `orm:"column(last_deploy);type(text);null"`
+	Audit               int16     `orm:"column(audit);null"`
+	KeepVersionNum      int       `orm:"column(keep_version_num)"`
+	CreatedAt           time.Time `orm:"column(created_at);type(datetime);null"`
+	UpdatedAt           time.Time `orm:"column(updated_at);type(datetime);null"`
+	ShowHistory         int16     `orm:"column(view_history)"` //显示较前次上线的代码变更
+	P2p                 int16     `orm:"column(p2p)"`
+	HostGroup           string    `orm:"column(host_group)"` //服务器分组，基于jumpserver groupid,groupid
+	Gzip                int16     `orm:"column(gzip)"`
+	IsGroup             int16     `orm:"column(is_group)"`
+	UserLock            int16     `orm:"column(user_lock)"` //用户锁定 uid
+	PmsProName          string    `orm:"column(pms_pro_name);size(200)"`
 }
 
 func (t *Project) TableName() string {

--- a/src/models/task.go
+++ b/src/models/task.go
@@ -30,6 +30,7 @@ type Task struct {
 	IsRun          int       `orm:"column(is_run);null"`
 	FileMd5        string    `orm:"column(file_md5);size(200);null"`
 	Hosts          string    `orm:"column(hosts);null"`
+	HostGroup      string    `orm:"column(host_group);null"`
 }
 
 func (t *Task) TableName() string {

--- a/src/models/user.go
+++ b/src/models/user.go
@@ -3,11 +3,13 @@ package models
 import (
 	"errors"
 	"fmt"
+	"github.com/astaxie/beego"
+	"github.com/astaxie/beego/orm"
+
+	"library/common"
 	"reflect"
 	"strings"
 	"time"
-
-	"github.com/astaxie/beego/orm"
 )
 
 type User struct {
@@ -21,6 +23,7 @@ type User struct {
 	Email                  string    `orm:"column(email);size(255)"`
 	Avatar                 string    `orm:"column(avatar);size(100);null"`
 	Role                   int16     `orm:"column(role)"`
+	FromLdap               int16     `orm:"column(from_ldap)"`
 	Status                 int16     `orm:"column(status)"`
 	CreatedAt              time.Time `orm:"column(created_at);type(datetime)"`
 	UpdatedAt              time.Time `orm:"column(updated_at);type(datetime)"`

--- a/src/routers/router.go
+++ b/src/routers/router.go
@@ -44,6 +44,10 @@ func init() {
 	beego.Router("/api/post/conf/save", &confcontrollers.SaveController{})
 	beego.Router("/api/get/conf/del", &confcontrollers.DelController{})
 	beego.Router("/api/get/conf/copy", &confcontrollers.CopyController{})
+	beego.Router("/api/get/conf/tags", &confcontrollers.TagsController{})
+	beego.Router("/api/get/conf/lock", &confcontrollers.LockController{})
+	beego.Router("/api/get/conf/server_groups", &confcontrollers.ServerGroupsController{})
+	beego.Router("/api/get/conf/groupinfo", &confcontrollers.GroupInfoController{})
 
 	beego.Router("/api/get/git/branch", &wallecontrollers.BranchController{})
 	beego.Router("/api/get/git/commit", &wallecontrollers.CommitController{})
@@ -57,6 +61,7 @@ func init() {
 	beego.Router("/api/get/task/chart", &taskcontrollers.TaskChartController{})
 	beego.Router("/api/post/task/save", &taskcontrollers.SaveController{})
 	beego.Router("/api/get/task/get", &taskcontrollers.TaskController{})
+	beego.Router("/api/get/task/changes", &taskcontrollers.ChangesController{})
 	beego.Router("/api/get/task/last", &taskcontrollers.LastTaskController{})
 	beego.Router("/api/get/task/rollback", &taskcontrollers.RollBackController{})
 	beego.Router("/api/get/task/del", &taskcontrollers.DelController{})

--- a/vue-gopub/config/dev.env.js
+++ b/vue-gopub/config/dev.env.js
@@ -2,5 +2,6 @@ var merge = require('webpack-merge')
 var prodEnv = require('./prod.env')
 
 module.exports = merge(prodEnv, {
-    NODE_ENV: '"development"'
+    NODE_ENV: '"development"',
+    API_URL:'"http://127.0.0.1:8192"'
 })

--- a/vue-gopub/config/prod.env.js
+++ b/vue-gopub/config/prod.env.js
@@ -1,3 +1,4 @@
 module.exports = {
-    NODE_ENV: '"production"'
+    NODE_ENV: '"production"',
+    API_URL: '""'
 }

--- a/vue-gopub/src/common/port_uri/conf.js
+++ b/vue-gopub/src/common/port_uri/conf.js
@@ -1,15 +1,18 @@
 //配置数据列表
-exports.list = "/api/get/conf/list"
-exports.mylist = "/api/get/conf/mylist"
+exports.list = process.env.API_URL+"/api/get/conf/list"
+exports.mylist = process.env.API_URL+"/api/get/conf/mylist"
 //根据id查询数据
-exports.get = "/api/get/conf/get"
+exports.get = process.env.API_URL+"/api/get/conf/get"
 //根据id删除数据
-exports.del = "/api/get/conf/del"
+exports.del = process.env.API_URL+"/api/get/conf/del"
 //添加或修改数据
-exports.save = "/api/post/conf/save"
+exports.save = process.env.API_URL+"/api/post/conf/save"
 //检查
-exports.detection = "/api/get/walle/detection"
+exports.detection = process.env.API_URL+"/api/get/walle/detection"
 //复制项目
-exports.copy = "/api/get/conf/copy"
-
+exports.copy = process.env.API_URL+"/api/get/conf/copy"
+exports.tags = process.env.API_URL+"/api/get/conf/tags"
+exports.lock = process.env.API_URL+"/api/get/conf/lock"
+exports.server_groups = process.env.API_URL+"/api/get/conf/server_groups"
+exports.groupinfo = process.env.API_URL+"/api/get/conf/groupinfo"
 

--- a/vue-gopub/src/common/port_uri/file.js
+++ b/vue-gopub/src/common/port_uri/file.js
@@ -1,2 +1,2 @@
 //获取文件md5
-exports.md5 = "/api/get/walle/md5"
+exports.md5 = process.env.API_URL+"/api/get/walle/md5"

--- a/vue-gopub/src/common/port_uri/git.js
+++ b/vue-gopub/src/common/port_uri/git.js
@@ -1,12 +1,12 @@
 //获取分支
-exports.branch = "/api/get/git/branch"
+exports.branch = process.env.API_URL+"/api/get/git/branch"
 //获取tag
-exports.getTag = "/api/get/git/tag"
+exports.getTag = process.env.API_URL+"/api/get/git/tag"
 //获取提交
-exports.commit = "/api/get/git/commit"
+exports.commit = process.env.API_URL+"/api/get/git/commit"
 
-exports.gitlog = "/api/get/git/gitlog"
-exports.gitpull = "/api/get/git/gitpull"
+exports.gitlog = process.env.API_URL+"/api/get/git/gitlog"
+exports.gitpull = process.env.API_URL+"/api/get/git/gitpull"
 
 //获取分支
-exports.jenkinsBranch = "/api/get/jenkins/commit"
+exports.jenkinsBranch = process.env.API_URL+"/api/get/jenkins/commit"

--- a/vue-gopub/src/common/port_uri/other.js
+++ b/vue-gopub/src/common/port_uri/other.js
@@ -10,4 +10,4 @@
  */
 
 //统计未进行预发布的项目
-exports.noauto = "/api/get/other/noauto"
+exports.noauto = process.env.API_URL+"/api/get/other/noauto"

--- a/vue-gopub/src/common/port_uri/p2p.js
+++ b/vue-gopub/src/common/port_uri/p2p.js
@@ -10,8 +10,8 @@
  */
 
 //获取用户信息
-exports.check = "/api/get/p2p/check"
+exports.check = process.env.API_URL+"/api/get/p2p/check"
     //用户登录
-exports.send = "/api/get/p2p/send"
+exports.send = process.env.API_URL+"/api/get/p2p/send"
     //用户登出
-exports.agent = "/api/post/p2p/agent"
+exports.agent = process.env.API_URL+"/api/post/p2p/agent"

--- a/vue-gopub/src/common/port_uri/record.js
+++ b/vue-gopub/src/common/port_uri/record.js
@@ -1,5 +1,5 @@
 //配置数据列表
-exports.list = "/api/get/record/list"
+exports.list = process.env.API_URL+"/api/get/record/list"
 //根据id查询数据
-exports.get = "/api/get/record/get"
+exports.get = process.env.API_URL+"/api/get/record/get"
 

--- a/vue-gopub/src/common/port_uri/task.js
+++ b/vue-gopub/src/common/port_uri/task.js
@@ -1,17 +1,19 @@
 //配置数据列表
-exports.list = "/api/get/task/list"
+exports.list = process.env.API_URL+"/api/get/task/list"
 //根据id查询数据
-exports.get = "/api/get/task/get"
+exports.get = process.env.API_URL+"/api/get/task/get"
 //根据id删除数据
-exports.del = "/api/get/task/del"
+exports.del = process.env.API_URL+"/api/get/task/del"
 //添加或修改数据
-exports.save = "/api/post/task/save"
+exports.save = process.env.API_URL+"/api/post/task/save"
 //上线接口
-exports.release = "/api/get/walle/release"
+exports.release = process.env.API_URL+"/api/get/walle/release"
 //创建回滚任务接口
-exports.rollback = "/api/get/task/rollback"
+exports.rollback = process.env.API_URL+"/api/get/task/rollback"
 //创建回滚任务接口
-exports.flush = "/api/get/walle/flush"
+exports.flush = process.env.API_URL+"/api/get/walle/flush"
 //图表接口
-exports.chart = "/api/get/task/chart"
+exports.chart = process.env.API_URL+"/api/get/task/chart"
+//版本变更列表
+exports.changes = process.env.API_URL+"/api/get/task/changes"
    

--- a/vue-gopub/src/common/port_uri/user.js
+++ b/vue-gopub/src/common/port_uri/user.js
@@ -10,15 +10,15 @@
  */
 
 //获取用户信息
-exports.info = "/api/get/user/info"
+exports.info = process.env.API_URL+"/api/get/user/info"
 //用户登录
-exports.login = "/login"
+exports.login = process.env.API_URL+"/login"
 //用户登出
-exports.logout = "/logout"
+exports.logout = process.env.API_URL+"/logout"
 //修改用户密码
-exports.changepasswd = "/changePasswd"
+exports.changepasswd = process.env.API_URL+"/changePasswd"
     //用户注册
-exports.register = "/register"
+exports.register = process.env.API_URL+"/register"
 
-exports.users = "/api/get/user"
-exports.usersProject = "/api/get/user/project"
+exports.users = process.env.API_URL+"/api/get/user"
+exports.usersProject = process.env.API_URL+"/api/get/user/project"

--- a/vue-gopub/src/components/mainContent/headerSection/menuRight/index.vue
+++ b/vue-gopub/src/components/mainContent/headerSection/menuRight/index.vue
@@ -11,13 +11,7 @@
                     <el-dropdown-item class="dropdown-list">
                         <a href="javascript:" class="dropdown-btn" @click="user_click(1)">
                             <i class="icon fa fa-user"></i>
-                            <span>个人信息</span>
-                        </a>
-                    </el-dropdown-item>
-                    <el-dropdown-item class="dropdown-list">
-                        <a href="javascript:" class="dropdown-btn" @click="user_click(2)">
-                            <i class="icon fa fa-cog"></i>
-                            <span>注册用户</span>
+                            <span>修改密码</span>
                         </a>
                     </el-dropdown-item>
                     <el-dropdown-item class="dropdown-list">
@@ -81,8 +75,8 @@
     ,
         user_info()
         {
-            this.$router.push({path: '/user/changepasswd'})
-            //个人信息
+            this.$router.push({path: '/user/changepasswd?id='+store.state.user_info.user.Id})
+            
         }
     ,
         admin_setting()

--- a/vue-gopub/src/pages/conf/base.vue
+++ b/vue-gopub/src/pages/conf/base.vue
@@ -169,8 +169,9 @@
                     </el-form-item>
 
                      <el-form-item prop="old_password" class="login-itema" style="margin-top:-20px;margin-left:-25px">
-                    <label >是否开启p2p  ：</label> <span style="color:teal"> {{project_data.P2p== 0 ? 'No' : 'Yes'}} </span>
-                     <label style="margin-left:120px">是否开启gzip  ：</label> <span style="color:teal"> {{project_data.Gzip == 0 ? 'No' : 'Yes'}} </span>
+                     <el-form-item><label >部属方式  ：</label> <span style="color:teal"> {{project_data.ReleaseType== 0 ? '软链接' : '移动目录'}} </span></el-form-item>
+                     <el-form-item><label >是否开启p2p  ：</label> <span style="color:teal"> {{project_data.P2p== 0 ? 'No' : 'Yes'}} </span></el-form-item>
+                     <el-form-item><label>是否开启gzip  ：</label> <span style="color:teal"> {{project_data.Gzip == 0 ? 'No' : 'Yes'}} </span></el-form-item>
                     </el-form-item>
                  </el-form>
                 </div>

--- a/vue-gopub/src/pages/task/base.vue
+++ b/vue-gopub/src/pages/task/base.vue
@@ -21,7 +21,7 @@
                 <el-table-column
                         prop="id"
                         label="id"
-                        width="80">
+                        width="40">
                 </el-table-column>
                 <el-table-column
                         prop="realname"
@@ -53,7 +53,7 @@
                 </el-table-column>
                 <el-table-column
                         prop="commit_id"
-                        label="	上线commit号">
+                        label="	commit号">
                 </el-table-column>
                 <el-table-column
                         prop="pms_batch_id"
@@ -85,7 +85,7 @@
                         </el-button>
                       <el-button type="warning" size="small" icon="share" @click="create_rollback_this(props.row.id)"
                                  v-if="props.row.status=='上线完成'&&props.row.action=='0'&&props.row.enable_rollback=='1' ">
-                        回滚当前
+                        回滚到当前
                       </el-button>
                         <el-button type="danger" size="small" icon="delete" v-if="props.row.status=='新建提交' || props.row.status=='上线失败'"
                                    @click="delete_data(props.row.id)">删除

--- a/vue-gopub/src/pages/task/create.vue
+++ b/vue-gopub/src/pages/task/create.vue
@@ -1,74 +1,68 @@
 <template>
-  <div class="panel">
-    <panel-title :title="$route.meta.title"></panel-title>
-    <div class="panel-body"
-         v-loading="load_data"
-         element-loading-text="拼命加载中">
-      <el-row>
-        <el-col :span="20">
-          <el-form label-width="100px">
-            <div class="panel-title">
-              预发布
-              <div class="fr">
+  <div>
 
-              </div>
-            </div>
-            <div class="panel-body">
-              <el-form-item label="项目名称:" label-width="100px">
-                <el-select v-model="pro_id" filterable placeholder="请选择" style="width: 400px;">
-                  <el-option
-                    v-for="item in options"
-                    :key="item.value"
-                    :label="item.label"
-                    :value="item.value">
-                  </el-option>
-                </el-select>
-              </el-form-item>
-            </div>
-            <div class="panel-title">
-              正式环境
-              <div class="fr">
+      <div class="panel">
+        <panel-title :title="$route.meta.title"></panel-title>
+        <div class="panel-body"
+             v-loading="load_data"
+             element-loading-text="拼命加载中">
+          <el-row>
+            <el-col :span="20">
+              <el-form label-width="100px">
+                <div class="panel-title">
+                  预发布
+                  <div class="fr">
 
-              </div>
-            </div>
-            <div class="panel-body">
-              <el-form-item label="项目名称:" label-width="100px">
-                <el-select v-model="pro_id1" filterable placeholder="请选择" style="width: 400px;">
-                  <el-option
-                    v-for="item in options1"
-                    :key="item.value"
-                    :label="item.label"
-                    :value="item.value">
-                  </el-option>
-                </el-select>
-              </el-form-item>
-            </div>
-            <el-form-item>
-              <el-button type="primary" @click="on_submit_form" :loading="on_submit_loading">创建
-              </el-button>
-              <el-button @click="$router.back()">返回</el-button>
-            </el-form-item>
-          </el-form>
-        </el-col>
-      </el-row>
-    </div>
+                  </div>
+                </div>
+                <div class="panel-body">
+                  <el-form-item label="项目名称:" label-width="100px">
+                    <el-select v-model="pro_id" filterable @change="select_project" placeholder="请选择" style="width: 400px;">
+                      <el-option
+                        v-for="item in options"
+                        :key="item.value"
+                        :label="item.label"
+                        :value="item.value">
+                        <span style="float: left">{{ item.label }}</span>
+                        <span style="float: right; color: #8492a6; font-size: 13px">{{ item.lockstatus }}</span>
+                      </el-option>
+                    </el-select>
+                    
+                  </el-form-item>
+                </div>
+                <el-form-item>
+                  <el-button type="primary" @click="on_submit_form" :loading="on_submit_loading" :disabled="btn_submit_disable">创建
+                  </el-button>
+                  <el-button @click="add_lock" :loading="on_submit_loading" :disabled="btn_add_lock_disable">锁定</el-button>
+                  <el-button @click="free_lock" :loading="on_submit_loading" :disabled="btn_free_lock_disable">解锁</el-button>
+                  
+                  <el-button @click="$router.back()">返回</el-button>
+                </el-form-item>
+              </el-form>
+            </el-col>
+          </el-row>
+        </div>
+      </div>
   </div>
 </template>
 <script type="text/javascript">
   import {panelTitle} from 'components'
   import {port_conf, port_code} from 'common/port_uri'
   import {tools_verify} from 'common/tools'
+  import store from 'store'
+
 
   export default {
     data() {
       return {
         projects: null,
         options: [],
-        options1: [],
         pro_id: null,
-        pro_id1: null,
         load_data: false,
-        on_submit_loading: false
+        on_submit_loading: false,
+        btn_submit_disable: true,
+        btn_add_lock_disable: true,
+        btn_free_lock_disable: true
       }
     },
     created() {
@@ -81,50 +75,122 @@
         this.$http.get(port_conf.mylist)
           .then(({data: {data}}) => {
             var opData = []
-            var opData1 = []
-            var opData2 = []
+            var uid = store.state.user_info.user.Id
             for (var i in data.table_data) {
               var value = data.table_data[i].id
               var env = ""
-              if (data.table_data[i].level == 1) {
-                env = "测试环境"
-                var lable = env + "-" + data.table_data[i].name
-                opData2.push({label: lable, value: value})
-              }
-              if (data.table_data[i].level == 2) {
-                env = "预发布环境"
-                var lable = env + "-" + data.table_data[i].name
-                opData.push({label: lable, value: value})
-              }
-              if (data.table_data[i].level == 3) {
-                env = "正式环境"
-                var lable = env + "-" + data.table_data[i].name
-                opData1.push({label: lable, value: value})
+              var lockstatus = ""
+              if(data.table_data[i].user_lock > 0){
+                if(data.table_data[i].user_lock == uid){
+                  lockstatus = data.table_data[i].lockuser+"锁定中"
+                }else{
+                  lockstatus = "锁定中"
+                }
               }
 
+
+              
+                env = "测试环境"
+                var lable = env + "-" + data.table_data[i].name
+                opData.push({label: lable, value: value, lockstatus:lockstatus})
+              
 
             }
             this.projects = data.table_data
             this.options = opData
-            this.options1 = opData1
             this.load_data = false
+            this.select_project()
             if (this.$route.query.id) {
               this.pro_id=this.$route.query.id
               this.on_submit_form()
             }
           }).catch(() => {
+
           this.load_data = false
         })
+      },
+      add_lock(){
+        var proId = 0
+        
+          proId = this.pro_id
+        
+        if (proId) {
+          this.$http.get(port_conf.lock, {
+                  params: {
+                    projectId:proId,
+                    act:1
+                  }
+              })
+              .then(({data: {data}}) => {
+              this.$message({
+                    message: "锁定成功！",
+                    type: 'success'
+                })
+              this.get_project_data()
+          })
+        }
+      },
+      free_lock(){
+        var proId = 0
+        
+        proId = this.pro_id
+        
+        if (proId) {
+          this.$http.get(port_conf.lock, {
+                  params: {
+                    projectId:proId,
+                    act:0
+                  }
+              })
+              .then(({data: {data}}) => {
+              this.$message({
+                    message: "解锁成功！",
+                    type: 'success'
+                })
+              this.get_project_data()
+          })
+        }
+      },
+      select_project(){
+        var uid = store.state.user_info.user.Id
+        var role = store.state.user_info.user.Role
+        var proId = 0
+        
+        proId = this.pro_id
+        if(!proId){
+          return 
+        }
+
+        for (var i in this.projects){
+          var project = this.projects[i]
+          if(project.id == proId){
+            if(project.user_lock > 0){
+              if(project.user_lock == uid){
+                this.btn_submit_disable=false
+                this.btn_add_lock_disable=true
+                this.btn_free_lock_disable=false
+              }else{
+                this.btn_submit_disable=true
+                this.btn_add_lock_disable=true
+                if(role == 1){
+                  this.btn_free_lock_disable=false
+                }else{
+                  this.btn_free_lock_disable=true
+                }
+              }
+            }else{
+              this.btn_submit_disable=false
+              this.btn_add_lock_disable=false
+              this.btn_free_lock_disable=true
+            }
+          }
+        }
       },
       //提交
       on_submit_form() {
         var proId = 0
-        if (this.pro_id) {
-          proId = this.pro_id
-        } else {
-          proId = this.pro_id1
-        }
-
+        proId = this.pro_id
+        
         if (proId) {
           for (var i in  this.projects) {
             var project = this.projects[i]

--- a/vue-gopub/src/pages/user/changepasswd.vue
+++ b/vue-gopub/src/pages/user/changepasswd.vue
@@ -6,24 +6,20 @@
                 <div> 个人信息设置</div>
             </div>
 
-     <div class="login-forma"  v-if="get_user_info.login">
+     <div class="login-forma"  v-if="userinfo.id">
                     <el-form ref="form" :model="form" :rules="rules" label-width="0">
                     <el-form-item prop="old_password" class="login-itema">
-                    <label >用户名 ：</label><span v-text="get_user_info.user.Username"></span>
+                    <label >用户名 ：</label><span v-text="userinfo.username"></span>
                     </el-form-item>
 
                       <el-form-item prop="old_password" class="login-itema">
-                    <label >邮箱 ：</label> <span v-text="get_user_info.user.Email"></span>
+                    <label >邮箱 ：</label> <span v-text="userinfo.email"></span>
                     </el-form-item>
 
                     <el-form-item prop="old_password" class="login-itema">
-                    <label >花名.实名 ：</label> <span v-text="get_user_info.user.Realname">  </span>    
+                    <label >花名.实名 ：</label> <span v-text="userinfo.realname">  </span>    
                     </el-form-item>
 
-                    <el-form-item prop="old_password" class="login-itema">
-                        <el-input type="password" v-model="form.old_password" placeholder="请输入旧密码："
-                                  class="form-inputa"></el-input>
-                    </el-form-item>
                     <el-form-item prop="newpassword" class="login-itema">
                         <el-input type="password" v-model="form.newpassword" placeholder="请输入新密码："
                                   class="form-inputa"></el-input>
@@ -44,25 +40,18 @@
 
 <script type="text/javascript">
     import {port_user} from 'common/port_uri'
-    import {mapGetters, mapActions} from 'vuex'
-    import {SET_USER_INFO} from 'store/actions/type'
-    import {GET_USER_INFO} from 'store/getters/type'
+    import store from 'store'
 
 
     export default{
-          computed: {
-                ...mapGetters({
-                    get_user_info: GET_USER_INFO
-                })
-    }
-    ,
         data(){
             return {
+                uid: this.$route.query.id,
+                userinfo:{},
                 form: {
-                
+                    uid:this.$route.query.id
                 },
                 rules: {
-                    old_password: [{required: true, message: '请输入旧密码：', trigger: 'blur'}],
                     newpassword: [{required: true, message: '请输入新密码：', trigger: 'blur'}],
                    repeat_newpassword: [{required: true, message: '确认新密码：', trigger: 'blur'}]
                 },
@@ -70,11 +59,29 @@
                 load_data: false
             }
         },
-        
+        created() {
+            var uid = store.state.user_info.user.Id
+            var role = store.state.user_info.user.Role
+            if (this.$route.query.id && (uid == this.$route.query.id || role == 1)) {
+                this.get_user_info()
+            }else{
+                this.$message({
+                    message: "无权访问",
+                    type: 'warning'
+                })
+            }
+        },
         methods: {
-                ...mapActions({
-                    set_user_info: SET_USER_INFO
-                }),
+        get_user_info(){
+            this.$http.get(port_user.users, {
+                  params: {
+                    id:this.uid
+                  }
+              })
+              .then(({data: {data}}) => {
+                    this.userinfo=data
+          })
+        },
         //提交
         submit_form() {
              this.$http.post(port_user.changepasswd,this.form)

--- a/vue-gopub/src/pages/user/list.vue
+++ b/vue-gopub/src/pages/user/list.vue
@@ -2,9 +2,12 @@
 
     <div class="panel">
         <panel-title :title="$route.meta.title">
+        
           <router-link style="float: left; margin-right: 10px" :to="{name: 'register'}" tag="span">
             <el-button type="primary" icon="plus" size="small">添加</el-button>
           </router-link>
+          <el-button type="warning" size="small" @click="sync_ldap()">从ldap同步</el-button>
+          <el-button type="warning" size="small" @click="test_ldap()">测试ldap</el-button>
         </panel-title>
 
         <div class="panel-body">
@@ -51,6 +54,13 @@
                   </template>
                 </el-table-column>
                 <el-table-column
+                        prop="ldap"
+                        label=" 用户来源" width="100">
+                  <template scope="props">
+                    <span  >{{ props.row.from_ldap | isLdap }}</span>
+                  </template>
+                </el-table-column>
+                <el-table-column
                         label="操作"
                         width="300">
                     <template scope="props">
@@ -58,8 +68,12 @@
                                      tag="span">
                             <el-button size="small" icon="edit">修改</el-button>
                         </router-link>
+                        <router-link :to="{name: 'changepasswd', query:  {id: props.row.id}}"
+                                     tag="span" v-if="props.row.from_ldap==0">
+                            <el-button size="small" icon="edit">设置密码</el-button>
+                        </router-link>
                         <el-button type="danger" size="small" icon="delete"
-                                   @click="delete_data(props.row.id)">删除
+                                   @click="delete_data(props.row.id)" v-if="props.row.from_ldap==0">删除
                         </el-button>
                     </template>
                 </el-table-column>
@@ -83,6 +97,13 @@
           }
           return value
         },
+        isLdap: function(value){
+            if (value==1){
+                return "ldap用户"
+            }else{
+                return "gopub用户"
+            }
+        }
       },
         data(){
             return {
@@ -124,7 +145,7 @@
                 catch(() => {
                     this.load_data = false
             })
-            },
+            }
 
         }
     }

--- a/vue-gopub/src/pages/user/register.vue
+++ b/vue-gopub/src/pages/user/register.vue
@@ -2,7 +2,7 @@
   <div class="login-bodya">
     <div class="loginWarpa">
       <div class="login-titlea">
-        <div> 用户注册</div>
+        <div> {{title}}</div>
       </div>
       <div class="login-forma">
         <el-form ref="form" :model="form" :rules="rules" label-width="0">
@@ -14,13 +14,13 @@
 
           <el-form-item prop="register_realname" class="login-itema">
             <label class="labela">花名.实名 ：</label>
-            <el-input v-model="form.register_realname" placeholder="输入规范如：春哥.李宇春" class="form-inputa"
+            <el-input v-bind:readonly="isLocked" v-model="form.register_realname" placeholder="输入规范如：春哥.李宇春" class="form-inputa"
                       :autofocus="true"></el-input>
           </el-form-item>
 
           <el-form-item prop="register_email" class="login-itema">
             <label class="labela">邮箱 ：</label>
-            <el-input v-model="form.register_email" placeholder="请输入联系邮箱：" class="form-inputa"
+            <el-input v-bind:readonly="isLocked" v-model="form.register_email" placeholder="请输入联系邮箱：" class="form-inputa"
                       :autofocus="true"></el-input>
           </el-form-item>
           <el-form-item label="用户类型:" label-width="100px">
@@ -41,7 +41,7 @@
             </el-select>
           </el-form-item>
           <el-form-item class="login-item">
-            <el-button size="large" class="form-submita" @click="submit_forma">确认注册</el-button>
+            <el-button size="large" class="form-submita" @click="submit_forma">{{submit_btn}}</el-button>
           </el-form-item>
         </el-form>
       </div>
@@ -56,6 +56,8 @@
   export default {
     data() {
       return {
+        title: "",
+        submit_btn: "",
         projects: null,
         options: [],
         pro_id: [],
@@ -65,6 +67,7 @@
           pro_ids: ""
         },
         isReadonly:false,
+        isLocked:false,
         rules: {
           register_username: [{required: true, message: '请输入账户名！', trigger: 'blur'}],
           register_realname: [{required: true, message: '请输入花名.实名！', trigger: 'blur'}],
@@ -76,8 +79,12 @@
       }
     },
     created() {
+      this.title="用户注册"
+      this.submit_btn="确认注册"
       if(this.userId>0){
         this.get_data()
+        this.title="用户信息修改"
+        this.submit_btn="确认修改"
       }
       this.get_project_data()
     },
@@ -99,8 +106,12 @@
             this.form.register_username=data.username
             this.form.register_realname=data.realname
             this.form.register_email=data.email
+            this.form.from_ldap=data.from_ldap
             this.form.Role=data.role|0
             this.isReadonly=true
+            if(data.from_ldap==1){
+              this.isLocked=true
+            }
             this.get_user_pro_data()
             this.load_data = false
           }).catch(() => {


### PR DESCRIPTION
之前使用walle很多，并进行了很多二开，在gopub上同步了之前的功能二开，包含：
1，增加基于ldap进行用户验证：
在ldap上创建用户账号相关，并加入到gopub开头的用户组中，首次在gopub上验证通过并登录时，会自动在gopub用户表中同步创建账号信息（不含密码），具体用户权限依然在gopub上进行
2，增加在上线时查看版本对比的功能
在上线，会显示当前上线版本与上次上线版本的文件差异，上线用户可以对变更的内容进行确认，防止误上线他人修改的文件
3，增加上线项目的锁定功能
主要针对测试环境部署进行，如A用户锁定了该上线项目，其他用户不能再进行上线操作。只有锁定用户或管理员可以进行解锁
4，为上线项目增加了标签属性，不过目前没有具体应用
5，增加了移动目录的上线方式
原系统只支持基于软链接的部署方式，即代码实际部署在release目录，通过软链接定位到wwwroot目录中，但在php开启opcache的情况下，此时需要重启php-fpm。帮增加本方式。
6，增加了基于jumpserver指定服务器分组上线
原系统基于ip列表进行，实际生产环境中，有些团队会使用jumpserver(https://github.com/jumpserver/jumpserver)管理线上服务器。所以增加了基于api获取服务器及对应服务器ip方式，指定部署目标服务器。当jumpserver的指定分组中增加或删除服务器时，代码部署不受影响。
目前jumpserver采用1.5.3版本，服务器分组采用node方式。
好像就这些。。